### PR TITLE
Updating setup.py to require Shapely version 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='geojson-precision',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=['click', 'cligj', 'shapely'],
+      install_requires=['click', 'cligj', 'shapely>=1,<2'],
       entry_points="""
       [console_scripts]
       geojson-precision=geojson_precision.cli:main


### PR DESCRIPTION
Updating setup.py to require Shapely version 1, since version 2 is not compatible with `geojson-precision` at present.

This fixes the `ImportError: cannot import name 'asShape' from 'shapely.geometry'` error reported in #3, and allowed me to run `geojson-precision` successfully.

Note that Shapely outputs the following deprecation warning message:

```
/usr/local/lib/python3.8/dist-packages/geojson_precision-0.0.1-py3.8.egg/geojson_precision/__init__.py:19: ShapelyDeprecationWarning: The proxy geometries (through the 'asShape()', 'asMultiPolygon()' or 'MultiPolygonAdapter()' constructors) are deprecated and will be removed in Shapely 2.0. Use the 'shape()' function or the standard 'MultiPolygon()' constructor instead.
  geom = asShape(feature['geometry'])
```

Fixes #3.
